### PR TITLE
Fix issue - Show history without any category

### DIFF
--- a/captains_log/cli/console_script.py
+++ b/captains_log/cli/console_script.py
@@ -60,7 +60,7 @@ from captains_log.cli.add_entry import add_entry_command
 from captains_log.cli.remove_entry import remove_entry_command
 from captains_log.cli.entries_history import entries_history_command
 from captains_log.cli.installer import install_command, reset_command
-from captains_log.cli.devdebug import foo_command
+#from captains_log.cli.devdebug import foo_command
 
 # Attach commands methods to the main grouper
 cli_frontend.add_command(add_entry_command, name="add")

--- a/captains_log/renderer/history.py
+++ b/captains_log/renderer/history.py
@@ -75,7 +75,10 @@ class ColumnedHistoryRenderer(ColoredOutputMixin, GrouperRenderer):
         """
         Find the most largest category name used from all entries
         """
-        self.largest_category_name = max([k for k in self.categories if k], key=len)
+        try:
+            self.largest_category_name = max([k for k in self.categories if k], key=len)
+        except ValueError:
+            self.largest_category_name = ""
         # Calculate the most largest ID representation when formatted using the 
         # last entry (that should allways have the higher id)
         self.largest_entry_id = len(super(ColumnedHistoryRenderer, self).format_id(self.ending_entry.id))


### PR DESCRIPTION
After a quick and dirty install cycle:

pip install python-captains-log
captains-log install
captains-log add "fooooo"
captains-log history
....
---> 78         self.largest_category_name = max([k for k in self.categories if k], key=len) or None
     79         # Calculate the most largest ID representation when formatted using the
     80         # last entry (that should allways have the higher id)

ValueError: max() arg is an empty sequence

Quick workarround to solve the issue
